### PR TITLE
Config.uk: Add dependencies for POSIX libraries

### DIFF
--- a/Config.uk
+++ b/Config.uk
@@ -6,6 +6,8 @@ menuconfig LIBNGINX
 	select LIBPOSIX_PROCESS
 	select LIBPOSIX_USER
 	select LIBPOSIX_SYSINFO
+	select LIBPOSIX_SOCKET
+	select LIBPOSIX_EVENT
 	select LIBUKMMAP
 	select LIBUKTIME
 	select LIBNEWLIBC


### PR DESCRIPTION
Release 0.10 added `posix-socket` and `posix-event` internal libraries to the Unikraft core. Consequently, libraries requiring networking support need to be updated to include `posix-socket` and `posix-event`.

This commit adds `LIBPOSIX_SOCKET` and `LIBPOSIX_EVENT` dependencies to `Config.uk`.

Fix #8 