### PR TITLE
Makefile.uk: Remove -Werror compile flag

### DIFF
--- a/Makefile.uk
+++ b/Makefile.uk
@@ -78,7 +78,7 @@ LIBNGINX_CINCLUDES-$(CONFIG_LIBNGINX_STREAM) += -I$(LIBNGINX_SRC)/stream
 ################################################################################
 # Flags
 ################################################################################
-LIBNGINX_FLAGS = -Wpointer-arith -Werror
+LIBNGINX_FLAGS = -Wpointer-arith
 
 # Suppress some warnings to make the build process look neater
 LIBNGINX_FLAGS_SUPPRESS = -Wno-unused-parameter -Wno-unused-variable	\


### PR DESCRIPTION
When building with Musl, `lib-nginx` gives
some warnings which break the build.
Until the warnings are resolved, the
-Werror flag should be removed.

Signed-off-by: Stefan Jumarea <stefanjumarea02@gmail.com>