### PR TITLE
Introduce Library.uk

### DIFF
--- a/Library.uk
+++ b/Library.uk
@@ -1,0 +1,5 @@
+name        := "nginx"
+description := "A HTTP and reverse proxy, a mail proxy, and a generic TCP/UDP proxy server."
+homepage    := "https://nginx.org/"
+version     := 1.15.6 sha256:a3d8c67c2035808c7c0d475fffe263db8c353b11521aa7ade468b780ed826cc6 http://nginx.org/download/nginx-1.15.6.tar.gz
+license     := "BSD-2-Clause"


### PR DESCRIPTION
This new file represents the first step towards proper versioning support of external microlibrary in Unikraft.  The file itself acts as mechanism for holding metadata-only values about the microlibrary.  This metadata is designed to be compatible with GNU Make whilst simultaneously being human-readable and readable by programs that are not GNU Make (e.g. tools such as KraftKit).

An important feature of this file is the inclusion of microlibrary versions. In a later step, once relevant integrations have been made to Unikrat's core build system and to relevant tools such as KraftKit, the user will be able to see and select from different versions of the microlibrary.

In this initial commit, the relevant metadata is absorbed from both Makefile.uk, Config.uk, but also includes new information such as SPDX License identifier. 

