### PR TITLE
`Config.uk`: Imply `LIBUKMMAP`

### DIFF
--- a/Config.uk
+++ b/Config.uk
@@ -8,7 +8,7 @@ menuconfig LIBNGINX
 	select LIBPOSIX_SYSINFO
 	select LIBPOSIX_SOCKET
 	select LIBPOSIX_EVENT
-	select LIBUKMMAP
+	imply LIBUKMMAP
 	select LIBUKTIME
 	select LIBUKSIGNAL
 	select LIBMUSL


### PR DESCRIPTION
Change `select LIBUKMMAP` to `imply LIBUKMMAP`. This is because `LIBUKMMAP` may not be required for the Nginx build (and use `LIBPOSIX_MMAP` instead).

With `select` in place you cannot disable `LIBUKMMAP` resulting in a dependency erorr when enabling `LIBPOSIX_MMAP`.

With `imply` as a soft select, `LIBUKMMAP` can be disabled, removing the dependency error.